### PR TITLE
feat: changed udev rule to match devices with multiple filesystems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 *.spk
+.DS_Store

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.8.1
+ - changed: udev rule so that the autorun script also gets executed on devices with multiple partitions/filesystems.
+
 1.8
  !!! A MANUAL STEP IS REQUIRED AFTER THE INSTALLATION !!!
  Third Party packages are restricted by Synology in DSM 7. Since autorun does require root 

--- a/INFO
+++ b/INFO
@@ -1,5 +1,5 @@
 package="autorun"
-version="1.8"
+version="1.8.1"
 maintainer="Jan Reidemeister"
 description="Execute scripts when connecting external drives (USB / eSATA)."
 arch="noarch"

--- a/build
+++ b/build
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION="1.8"
+VERSION="1.8.1"
 
 rm package.tgz
 rm autorun-$VERSION.spk

--- a/package/autorun
+++ b/package/autorun
@@ -22,7 +22,7 @@ while ([ -z "$MOUNTPATH" ] && [ $COUNT -lt $TRIES ])
 do
 	MOUNTPATH=`/bin/mount 2>&1 | /bin/grep "/dev/$1" | /bin/cut -d ' ' -f3`
 	COUNT=$(($COUNT+1))
-	/bin/sleep 1s
+	/bin/sleep 4s
 done
 
 # abort when nothing is found

--- a/package/rules
+++ b/package/rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="block", ACTION=="add", ENV{DEVTYPE}=="partition", PROGRAM="/var/packages/autorun/target/udev %k"
+SUBSYSTEM=="block", ACTION=="add", ENV{ID_FS_USAGE}=="filesystem", RUN+="/var/packages/autorun/target/udev %k"


### PR DESCRIPTION
Hey, thanks for the sync package!
I had to adapt the dev rules a bit so the autorun script also gets executed on devices with multiple partitions/filesystems.

Is that something you'd want to "officially" support?