### PR TITLE
Basic security measure

### DIFF
--- a/INFO
+++ b/INFO
@@ -1,5 +1,5 @@
 package="autorun"
-version="1.8"
+version="1.9"
 maintainer="Jan Reidemeister"
 description="Execute scripts when connecting external drives (USB / eSATA)."
 arch="noarch"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ SSH to your NAS (as an admin user) and execute the following command:
 sudo cp /var/packages/autorun/conf/privilege.root /var/packages/autorun/conf/privilege
 ```
 
+# security considerations
+Everybody with physical access to your Disc Station is able to execute any command as root by
+plugging in a USB-Stick with an 'autorun' script. If this is an issue for you, there will be two options:
+
+(1) set a different name for the autorun script (via installation wizard or by changing ``SCRIPT`` setting in file ``/var/packages/autorun/target/config``)
+
+(2) set a key which must be present on the device in file ``/key`` (via installation wizard or by changing ``KEY`` setting in file ``/var/packages/autorun/target/config``)
 
 # build
 Should run on any *nix box / subsystem.

--- a/WIZARD_UIFILES/install_uifile
+++ b/WIZARD_UIFILES/install_uifile
@@ -45,6 +45,24 @@
         }] 
     }] 
 },{
+    "step_title": "Security settings",
+    "items": [{
+            "type": "textfield",
+            "desc": "You can enable basic security by defining a key here. Only if the plugged in device presents the key in file '/key', autorun will be executed. You can leave the key blank to disable this feature.",
+            "subitems": [{
+                    "key": "config_key",
+                    "desc": "Key",
+                    "defaultValue": "",
+                    "validator": {
+                            "allowBlank": true,
+                            "regex": {
+                                "expr": "/^[^\\\\';()]*$/",
+                                "errorText": "The following symbols are not allowed: \", ', ;, (, ), \\"
+                            }
+                    }
+            }]
+        }]
+},{
     "step_title": "IMPORTANT: Manual Action Required!",
     "items": [{
         "type": "textfield", 

--- a/build
+++ b/build
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION="1.8"
+VERSION="1.9"
 
 rm package.tgz
 rm autorun-$VERSION.spk

--- a/package/autorun
+++ b/package/autorun
@@ -40,6 +40,20 @@ logInfo "device '$1' - mount point '$MOUNTPATH' found"
 if [ -x "$MOUNTPATH/$SCRIPT" ]
 then
 	# yes
+	if [ "$KEY" != "" ]
+	then
+		if [ ! -r "$MOUNTPATH/key" ]
+		then
+	    	logError "device '$1' - script '$MOUNTPATH/$SCRIPT' found, but no device key exists under '$MOUNTPATH/key'. Aborting"
+    		exit 0
+		fi
+		DEVICE_KEY=`cat "$MOUNTPATH/key"`
+		if [ "$KEY" != "$DEVICE_KEY" ]
+		then
+			logError "device '$1' - script '$MOUNTPATH/$SCRIPT' found, but device key does not match. Aborting"
+			exit 0
+		fi
+	fi
 	logInfo "device '$1' - script '$MOUNTPATH/$SCRIPT' found, executing"
 	if [ $BEEP = "1" ]
 	then

--- a/scripts/postinst
+++ b/scripts/postinst
@@ -6,10 +6,13 @@ eval $(env | grep "^config_search=")
 eval $(env | grep "^config_wait=")
 eval $(env | grep "^config_beep=")
 eval $(env | grep "^config_led=")
+eval $(env | grep "^config_key=")
 
 echo "SCRIPT=$config_script" > "$SYNOPKG_PKGDEST/config"
 echo "TRIES=$config_search" >> "$SYNOPKG_PKGDEST/config"
 echo "WAIT=$config_wait" >> "$SYNOPKG_PKGDEST/config"
+echo "KEY='$config_key'" >> "$SYNOPKG_PKGDEST/config"
+
 if [ $config_beep = "true" ]
 then
 	echo "BEEP=1" >> "$SYNOPKG_PKGDEST/config"


### PR DESCRIPTION
- autorun will only be executed if the pre-defined KEY is present on the device under file '/key'
- if KEY is empty, the feature will be ignored